### PR TITLE
[Bugfix] Fixes the default value for the pagination values

### DIFF
--- a/WebApi.Models/Request/ListRequest.cs
+++ b/WebApi.Models/Request/ListRequest.cs
@@ -10,8 +10,30 @@
             this.Size = size;
         }
 
-        public int Page { get; set; } = 1;
+        private int _page = 1;
+        public int Page
+        {
+            get => _page;
+            set
+            {
+                if(value != 0)
+                {
+                    _page = value;
+                }
+            }
+        }
 
-        public int Size { get; set; } = 10;
+        private int _size = 10;
+        public int Size
+        {
+            get => _size;
+            set
+            {
+                if (value != 0)
+                {
+                    _size = value;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
![Git Merge](https://camo.githubusercontent.com/803261fbe049c6c1631247f42912f216cc4c08b00f4ac25b54145b14f3cc42d8/68747470733a2f2f6d65646961312e74656e6f722e636f6d2f696d616765732f64653862653536383061383161636262313666326661346161616265663465612f74656e6f722e6769663f6974656d69643d3133323131313132)

### Status

READY

### Whats?

Fixes a possible bug when the variables are set to zero.

### Why?

Because we mainly use this to paginate our queries, and when we send the value zero in the query string, the model sets it to zero. 

When it sends a zero value to the query, at least in mongodb, the limit method when it receives zero, means that it has no limit (it will bring the whole matching query and it can be 1 million documents).
