### PR TITLE
Add BadGateway to ApiResponse

### DIFF
--- a/WebApi.Models.Tests/Response/ApiResponseTest.cs
+++ b/WebApi.Models.Tests/Response/ApiResponseTest.cs
@@ -103,5 +103,32 @@ namespace WebApi.Models.Tests.Response
             Assert.Equal("property", errors.Errors.First().Property);
             Assert.Empty(response.Headers);
         }
+
+        [Fact]
+        public static void BadGateway_Should_Return_BadGatewayResponse()
+        {
+            // arrange & act
+            var response = ApiResponse.BadGateway();
+
+            // assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+            Assert.Null(response.Content);
+            Assert.Empty(response.Headers);
+        }
+
+        [Fact]
+        public static void BadGateway_Should_Return_BadGatewayResponse_With_Content()
+        {
+            // arrange & act
+            var response = ApiResponse.BadGateway("test");
+
+            // assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+            Assert.NotNull(response.Content);
+            Assert.Equal("test", response.Content.ToString());
+            Assert.Empty(response.Headers);
+        }
     }
 }

--- a/WebApi.Models/Response/ApiResponse.cs
+++ b/WebApi.Models/Response/ApiResponse.cs
@@ -70,5 +70,14 @@ namespace WebApi.Models.Response
                 Content = ErrorsResponse.WithSingleError(message, property)
             };
         }
+
+        public static ApiResponse BadGateway(object content = null)
+        {
+            return new ApiResponse
+            {
+                Content = content,
+                StatusCode = HttpStatusCode.BadGateway
+            };
+        }
     }
 }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/tsX3YMWYzDPjAARfeg/giphy.gif)

### Status

READY 

### Whats?

Added  BadGateway to ApiResponse.

### Why?

In order to have an option to return a BadGatewayResponse without needing to throw an Exception.

### How?

By adding a BadGatewayMethod to the ApiResponse class.

### Attachments
New and old unit tests passing:
![image](https://user-images.githubusercontent.com/49206390/212941588-5cfd9527-3dd1-48f0-863e-9bfe46262215.png)

### Definition of Done:
- [x] Implements unit tests
